### PR TITLE
fix: use complete status in workflow

### DIFF
--- a/frontend/src/services/__tests__/ProjectService.spec.ts
+++ b/frontend/src/services/__tests__/ProjectService.spec.ts
@@ -13,7 +13,7 @@ describe('ProjectService', () => {
     it('should fetch all projects successfully', async () => {
       const mockProjects = [
         { id: 1, name: 'Project 1', status: 'active' },
-        { id: 2, name: 'Project 2', status: 'completed' }
+        { id: 2, name: 'Project 2', status: 'complete' }
       ]
 
       ;(global.fetch as any).mockResolvedValueOnce({

--- a/frontend/src/services/projectWorkflowApi.ts
+++ b/frontend/src/services/projectWorkflowApi.ts
@@ -412,8 +412,8 @@ export class ProjectWorkflowAPI {
     userId?: string
   ): { route: string; params?: any; message?: string } | null {
     
-    // If project is finalized, active, or completed, go to project details
-    if (['finalized', 'active', 'completed'].includes(projectStatus)) {
+    // If project is finalized, active, or complete, go to project details
+    if (['finalized', 'active', 'complete'].includes(projectStatus)) {
       return {
         route: 'project-details',
         params: { id: userId }, // This should be projectId, will be corrected in calling code

--- a/frontend/tests/unit/getNextStepForUser.spec.ts
+++ b/frontend/tests/unit/getNextStepForUser.spec.ts
@@ -103,9 +103,9 @@ describe('getNextStepForUser', () => {
       })
     })
 
-    it('should handle completed status projects', () => {
+    it('should handle complete status projects', () => {
       const result = ProjectWorkflowAPI.getNextStepForUser(
-        { ...mockProject, workflow_status: 'completed' }, 
+        { ...mockProject, workflow_status: 'complete' },
         'director'
       )
       


### PR DESCRIPTION
## Summary
- align `getNextStepForUser` finalized states with `complete`
- update workflow tests and service mocks to use `complete`

## Testing
- `npm --prefix frontend run test:run` *(fails: Error loading upcoming meetings, ProjectService and projectWizard store tests)*

------
https://chatgpt.com/codex/tasks/task_b_68a2bbf4f620832b9a6892ecb40e9e01