### PR TITLE
Use fresh database schema in Docker setups

### DIFF
--- a/backend/database/migrate.js
+++ b/backend/database/migrate.js
@@ -14,8 +14,9 @@ const pool = new Pool({
 
 class DatabaseMigrator {
     constructor() {
-        this.migrationsPath = path.join(__dirname, 'migrations');
-        this.schemaPath = path.join(__dirname);
+        // Look for SQL under the repo-root /database folder
+        this.schemaPath = path.resolve(__dirname, '..', '..', 'database');
+        this.migrationsPath = path.join(this.schemaPath, 'migrations');
     }
 
     /**
@@ -109,9 +110,9 @@ class DatabaseMigrator {
             await this.initializeMigrationTable();
             
             // Check if main schema needs to be applied
-            const schemaFile = path.join(this.schemaPath, 'schema.sql');
+            const schemaFile = path.join(this.schemaPath, 'fresh_schema.sql');
             if (fs.existsSync(schemaFile)) {
-                await this.executeSqlFile(schemaFile, 'schema.sql');
+                await this.executeSqlFile(schemaFile, 'fresh_schema.sql');
             }
             
             // Check if gate meeting enhancements need to be applied

--- a/database/README.md
+++ b/database/README.md
@@ -4,10 +4,10 @@ This folder contains the essential database files for the PFMT Integrated Applic
 
 ## Current Files
 
-### `schema.sql` - **MAIN SCHEMA FILE**
-- **Purpose**: Complete unified database schema for PFMT application
+### `fresh_schema.sql` - **BASELINE SCHEMA**
+- **Purpose**: Complete unified database schema for the PFMT application
 - **Usage**: Apply this file to create the entire database structure
-- **Command**: `psql -d pfmt_integrated -f schema.sql`
+- **Command**: `psql -d pfmt_integrated -f fresh_schema.sql`
 - **Contains**:
   - All table definitions with UUID primary keys
   - Enhanced audit logging system
@@ -17,10 +17,10 @@ This folder contains the essential database files for the PFMT Integrated Applic
   - Comprehensive indexes and constraints
   - Triggers for audit logging and updated_at columns
 
-### `minimal_working_seeds.sql` - **SEED DATA**
-- **Purpose**: Essential seed data for development and testing
-- **Usage**: Apply after schema to populate lookup tables and demo data
-- **Command**: `psql -d pfmt_integrated -f minimal_working_seeds.sql`
+### `seed.sql` - **SEED DATA**
+- **Purpose**: Sample data for development and testing
+- **Usage**: Apply after the schema to populate lookup tables and demo data
+- **Command**: `psql -d pfmt_integrated -f seed.sql`
 - **Contains**:
   - Demo users (3 users)
   - Demo vendors (2 vendors)
@@ -33,19 +33,20 @@ This folder contains the essential database files for the PFMT Integrated Applic
 
 1. **First**: Apply the schema
    ```bash
-   psql -d pfmt_integrated -f schema.sql
+   psql -d pfmt_integrated -f fresh_schema.sql
    ```
 
 2. **Second**: Apply the seed data
    ```bash
-   psql -d pfmt_integrated -f minimal_working_seeds.sql
+   psql -d pfmt_integrated -f seed.sql
    ```
 
 ## Removed Files
 
 The following obsolete files have been removed from this repository:
 
-### Obsolete Schema Files (replaced by unified schema.sql):
+### Obsolete Schema Files (replaced by `fresh_schema.sql`):
+- `schema.sql`
 - `approval_audit_schema.sql`
 - `financial_management_schema.sql`
 - `fix_uuid_schema.sql`
@@ -53,8 +54,8 @@ The following obsolete files have been removed from this repository:
 - `wizard_schema.sql`
 - `wizard_schema_fixed.sql`
 
-### Obsolete Seed Files (replaced by minimal_working_seeds.sql):
-- `seed.sql`
+### Obsolete Seed Files (replaced by `seed.sql`):
+- `minimal_working_seeds.sql`
 - `demo_seeds.sql`
 - `corrected_demo_seeds.sql`
 - `comprehensive_seeds.sql`
@@ -103,6 +104,6 @@ GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO your_user;
 
 ---
 
-*Last updated: August 8, 2025*  
+*Last updated: August 18, 2025*
 *Schema version: 2.0.0 (Unified)*
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -16,7 +16,13 @@ services:
     volumes:
       # Use named volume for production data persistence
       - postgres_prod_data:/var/lib/postgresql/data
-      - ./database/schema.sql:/docker-entrypoint-initdb.d/01-schema.sql:ro
+      # Base schema (single source of truth)
+      - ./database/fresh_schema.sql:/docker-entrypoint-initdb.d/01-schema.sql:ro
+      # Optional: apply migrations on first boot
+      - ./database/migrations/001_add_lifecycle_status.sql:/docker-entrypoint-initdb.d/02-001_lifecycle.sql:ro
+      - ./database/migrations/002_complete_docker_fix.sql:/docker-entrypoint-initdb.d/03-002_docker_fix.sql:ro
+      # Seed data after schema and migrations
+      - ./database/seed.sql:/docker-entrypoint-initdb.d/99-seed.sql:ro
     # Don't expose database port in production
     ports: []
     logging:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,9 +11,15 @@ services:
       POSTGRES_INITDB_ARGS: "--encoding=UTF-8"
     volumes:
       - postgres_data:/var/lib/postgresql/data
-      - ./database/schema_complete.sql:/docker-entrypoint-initdb.d/01-schema.sql:ro
-      - ./database/seed.sql:/docker-entrypoint-initdb.d/02-seed.sql:ro
-      # REMOVED: ./database/fix_uuid_schema.sql (file does not exist)
+      # Base schema (single source of truth)
+      - ./database/fresh_schema.sql:/docker-entrypoint-initdb.d/01-schema.sql:ro
+
+      # Optional: follow-on migrations (if you want them applied on first boot)
+      - ./database/migrations/001_add_lifecycle_status.sql:/docker-entrypoint-initdb.d/02-001_lifecycle.sql:ro
+      - ./database/migrations/002_complete_docker_fix.sql:/docker-entrypoint-initdb.d/03-002_docker_fix.sql:ro
+
+      # Seed after schema/migrations
+      - ./database/seed.sql:/docker-entrypoint-initdb.d/99-seed.sql:ro
     ports:
       - "5432:5432"
     networks:

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -14,12 +14,10 @@ services:
     volumes:
       - pfmt_db_data:/var/lib/postgresql/data
       # Initialize with schema and seed data
-      - ../database/schema.sql:/docker-entrypoint-initdb.d/01_schema.sql:ro
-      - ../database/seeds/001_phase1_sample_data.sql:/docker-entrypoint-initdb.d/02_seed.sql:ro
-      - ../database/approval_audit_schema.sql:/docker-entrypoint-initdb.d/03_approval_audit_schema.sql:ro
-      - ../database/financial_management_schema.sql:/docker-entrypoint-initdb.d/04_financial_management_schema.sql:ro
-      - ../database/vendor_management_schema.sql:/docker-entrypoint-initdb.d/05_vendor_management_schema.sql:ro
-      - ../database/wizard_schema.sql:/docker-entrypoint-initdb.d/06_wizard_schema.sql:ro
+      - ../database/fresh_schema.sql:/docker-entrypoint-initdb.d/01_schema.sql:ro
+      - ../database/migrations/001_add_lifecycle_status.sql:/docker-entrypoint-initdb.d/02_001_lifecycle.sql:ro
+      - ../database/migrations/002_complete_docker_fix.sql:/docker-entrypoint-initdb.d/03_002_docker_fix.sql:ro
+      - ../database/seed.sql:/docker-entrypoint-initdb.d/99_seed.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-pfmt_user} -d ${POSTGRES_DB:-pfmt_integrated}"]
       interval: 10s

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -16,13 +16,13 @@ services:
       POSTGRES_EFFECTIVE_CACHE_SIZE: 512MB
     volumes:
       - pfmt_db_prod_data:/var/lib/postgresql/data
-      # Initialize with schema and seed data
-      - ../database/schema.sql:/docker-entrypoint-initdb.d/01_schema.sql:ro
-      - ../database/seeds/001_phase1_sample_data.sql:/docker-entrypoint-initdb.d/02_seed.sql:ro
-      - ../database/approval_audit_schema.sql:/docker-entrypoint-initdb.d/03_approval_audit_schema.sql:ro
-      - ../database/financial_management_schema.sql:/docker-entrypoint-initdb.d/04_financial_management_schema.sql:ro
-      - ../database/vendor_management_schema.sql:/docker-entrypoint-initdb.d/05_vendor_management_schema.sql:ro
-      - ../database/wizard_schema.sql:/docker-entrypoint-initdb.d/06_wizard_schema.sql:ro
+      # Base schema for initial database
+      - ../database/fresh_schema.sql:/docker-entrypoint-initdb.d/01_schema.sql:ro
+      # Optional migrations applied on first boot
+      - ../database/migrations/001_add_lifecycle_status.sql:/docker-entrypoint-initdb.d/02_001_lifecycle.sql:ro
+      - ../database/migrations/002_complete_docker_fix.sql:/docker-entrypoint-initdb.d/03_002_docker_fix.sql:ro
+      # Seed data after schema and migrations
+      - ../database/seed.sql:/docker-entrypoint-initdb.d/99_seed.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-pfmt} -d ${POSTGRES_DB:-pfmt}"]
       interval: 30s


### PR DESCRIPTION
## Summary
- Mount `fresh_schema.sql`, migrations, and seed data across all Docker Compose files so containers initialize with a complete schema
- Redirect backend migration script to repo-level `database/` folder and baseline schema
- Update database README to document `fresh_schema.sql` and `seed.sql`

## Testing
- `npm test --prefix backend` *(fails: database and route errors)*
- `npm test --prefix frontend` *(fails: multiple missing API mocks)*

------
https://chatgpt.com/codex/tasks/task_b_68a2c1a130b4832b80d183e086596a3d