### PR TITLE
feat: include credentials in api requests

### DIFF
--- a/frontend/src/services/apiService.ts
+++ b/frontend/src/services/apiService.ts
@@ -88,6 +88,7 @@ class ApiService {
         }),
         ...options.headers
       },
+      credentials: 'include',
       ...options
     }
 


### PR DESCRIPTION
## Summary
- add `credentials: 'include'` to API request config so cookies are sent with fetch calls

## Testing
- `npm run test:run` (fails: ProjectWizard store and service tests)
- `node test_api_integration.js` (backend not available)


------
https://chatgpt.com/codex/tasks/task_b_68a2cece8f8c832b823c63988514dbe9