### PR TITLE
Rename transfer dialog label in BudgetManager

### DIFF
--- a/frontend/src/components/financial/BudgetManager.vue
+++ b/frontend/src/components/financial/BudgetManager.vue
@@ -431,7 +431,7 @@
             placeholder="0.00"
           />
           <AlbertaText variant="body-xs" color="secondary" class="mt-1">
-            Maximum available: ${{ formatCurrency(getAvailableForTransfer(transferForm.from_category_id)) }}
+            Amount available: ${{ formatCurrency(getAvailableForTransfer(transferForm.from_category_id)) }}
           </AlbertaText>
         </div>
 


### PR DESCRIPTION
## Summary
- Clarify transfer dialog field by renaming "Maximum available" to "Amount available"

## Testing
- `npm test -- --run --reporter=dot` *(fails: Test Files 4 failed | 3 passed (7))*

------
https://chatgpt.com/codex/tasks/task_b_68a2cec5b3b4832b82b3148a9597724c