### PR TITLE
test: assert project fields in project list

### DIFF
--- a/backend/tests/controllers.test.js
+++ b/backend/tests/controllers.test.js
@@ -79,6 +79,8 @@ describe('Controller Integration Tests', () => {
             const testProject = response.body.find(p => p.id === testProjectId);
             expect(testProject).toBeDefined();
             expect(testProject.project_name).toBe('Test Project');
+            expect(Number(testProject.budget)).toBeCloseTo(50000.00);
+            expect(testProject.created_by).toBe(testUserId);
         });
 
         test('GET /api/projects/:id should return specific project', async () => {


### PR DESCRIPTION
## Summary
- extend GET /api/projects test to verify project name, budget, and creator

## Testing
- `npm test tests/controllers.test.js` *(fails: connect ECONNREFUSED 127.0.0.1:5432)*

------
https://chatgpt.com/codex/tasks/task_b_68a2cede7144832bbc22d395915d443a