### PR TITLE
Use relative API base path

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -52,7 +52,7 @@ services:
     restart: always
     environment:
       # Production API URL (adjust based on your domain)
-      VITE_API_BASE_URL: ${API_BASE_URL:-http://localhost:3002/api}
+      VITE_API_BASE_URL: ${API_BASE_URL:-/api}
     logging:
       driver: "json-file"
       options:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,7 +77,7 @@ services:
     container_name: pfmt-frontend
     restart: unless-stopped
     environment:
-      VITE_API_BASE_URL: http://backend:3002/api
+      VITE_API_BASE_URL: /api
       VITE_APP_TITLE: PFMT Integrated
       VITE_APP_VERSION: 1.0.0
     ports:

--- a/documentation/PFMT_Technical_Specification.md
+++ b/documentation/PFMT_Technical_Specification.md
@@ -48,7 +48,7 @@
 
 **Frontend (.env)**
 
-* `VITE_API_BASE_URL` (e.g., `http://localhost:3002`)
+* `VITE_API_BASE_URL` (e.g., `/api`)
 * `VITE_APP_TITLE`
 
 ### 3.2 Ports & bindings

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,5 +1,5 @@
 // Simple API configuration for PFMT frontend
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3002';
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api';
 
 export const api = {
   baseURL: API_BASE_URL,

--- a/frontend/src/services/contractService.js
+++ b/frontend/src/services/contractService.js
@@ -5,7 +5,7 @@
 
 import axios from 'axios';
 
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000/api';
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api';
 
 // Create axios instance with default config
 const api = axios.create({

--- a/frontend/src/services/projectService.js
+++ b/frontend/src/services/projectService.js
@@ -5,7 +5,7 @@
 
 import axios from 'axios';
 
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000/api';
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api';
 
 // Create axios instance with default config
 const api = axios.create({

--- a/frontend/src/services/reportService.js
+++ b/frontend/src/services/reportService.js
@@ -5,7 +5,7 @@
 
 import axios from 'axios';
 
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000/api';
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api';
 
 // Create axios instance with default config
 const api = axios.create({

--- a/frontend/src/services/vendorService.js
+++ b/frontend/src/services/vendorService.js
@@ -5,7 +5,7 @@
 
 import axios from 'axios';
 
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3002/api';
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api';
 
 // Create axios instance with default config
 const api = axios.create({


### PR DESCRIPTION
## Summary
- Set `VITE_API_BASE_URL` to `/api` in compose files so the frontend talks to the backend via the Nginx proxy
- Default frontend service modules to a relative `/api` base path
- Document the new relative API base URL

## Testing
- `npm --prefix frontend run test:run` *(fails: Test Files 4 failed | 3 passed, Tests 52 failed | 70 passed)*
- `npm --prefix backend test` *(fails: Test Suites 5 failed | 1 passed, Tests 68 failed | 3 passed)*

------
https://chatgpt.com/codex/tasks/task_b_68a2cf5e042c832bb7a59269d509df06