### PR TITLE
Handle FormData payloads in ApiService

### DIFF
--- a/frontend/src/services/apiService.ts
+++ b/frontend/src/services/apiService.ts
@@ -76,16 +76,24 @@ class ApiService {
     }
     
     const currentUser = getCurrentUser()
-    
+    const headers: HeadersInit = {
+      // Add user context to headers with UUID format
+      ...(currentUser && {
+        'X-User-Id': convertUserIdToUuid(currentUser.id),
+        'X-User-Role': currentUser.role,
+        'X-User-Name': currentUser.name
+      })
+    }
+
+    const isFormData = typeof FormData !== 'undefined' && options.body instanceof FormData
+
+    if (!isFormData) {
+      headers['Content-Type'] = 'application/json'
+    }
+
     const config: RequestInit = {
       headers: {
-        'Content-Type': 'application/json',
-        // Add user context to headers with UUID format
-        ...(currentUser && {
-          'X-User-Id': convertUserIdToUuid(currentUser.id),
-          'X-User-Role': currentUser.role,
-          'X-User-Name': currentUser.name
-        }),
+        ...headers,
         ...options.headers
       },
       credentials: 'include',


### PR DESCRIPTION
## Summary
- avoid setting `Content-Type` header when request body is `FormData`

## Testing
- `npm test` *(fails: store.validateFinalization is not a function, and others)*
- `node <script>` (local server upload, returns multipart/form-data header)


------
https://chatgpt.com/codex/tasks/task_b_68a32d1b1918832bb3cdeadcfa959631