### PR TITLE
fix: align frontend proxy with backend port

### DIFF
--- a/frontend/src/services/apiService.ts
+++ b/frontend/src/services/apiService.ts
@@ -321,7 +321,7 @@ class ApiService {
     return {
       success: false,
       error: 'Backend service not available',
-      message: 'Please ensure the backend server is running on port 3002',
+      message: 'Please ensure the backend server is running and reachable',
       data: null as T
     }
   }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -24,10 +24,11 @@ export default defineConfig({
     hmr: {
       host: 'localhost'
     },
-    // Proxy API calls to backend service - Fixed for local development
+    // Proxy API calls to backend service
+    // Use BACKEND_PORT env variable if provided, default to 3002
     proxy: {
       '/api': {
-        target: 'http://localhost:3002', // Fixed: Use localhost and correct port 3002
+        target: `http://localhost:${process.env.BACKEND_PORT || '3002'}`,
         changeOrigin: true,
         secure: false,
       },


### PR DESCRIPTION
## Summary
- make frontend dev server proxy respect `BACKEND_PORT`
- clarify fallback message when backend unreachable
- default proxy to backend's 3002 port when `BACKEND_PORT` is unset

## Testing
- `npx vitest run` *(fails: ProjectService and project wizard tests)*

------
https://chatgpt.com/codex/tasks/task_b_68a337319e84832ba1abb0aab552ba7f