### PR TITLE
fix: import Role as type

### DIFF
--- a/frontend/src/composables/useProjectPermissions.ts
+++ b/frontend/src/composables/useProjectPermissions.ts
@@ -1,6 +1,8 @@
-import { computed, type Ref } from 'vue'
+import { computed } from 'vue'
+import type { Ref } from 'vue'
 import { useAuthStore } from '@/stores/auth'
-import { ROLES, type Role } from '@/constants/roles'
+import { ROLES } from '@/constants/roles'
+import type { Role } from '@/constants/roles'
 
 export interface ProjectPermissions {
   canView: boolean

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -2,17 +2,17 @@ import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
 import { UserAPI } from '@/services/apiService'
 import { useProjectStore } from './project'
-import { 
-  ROLES, 
-  Role, 
-  normalizeRole, 
-  isValidRole, 
+import {
+  ROLES,
+  normalizeRole,
+  isValidRole,
   ROLE_DISPLAY_NAMES,
   ROLE_GROUPS,
   isInRoleGroup,
   hasRoleOrHigher,
   getRolesForFeature
 } from '@/constants/roles'
+import type { Role } from '@/constants/roles'
 
 export interface User {
   id: string | number


### PR DESCRIPTION
## Summary
- ensure auth store imports Role as a type to avoid runtime export errors
- update project permissions composable to use type-only Role import

## Testing
- `npm run test:run` *(fails: 33 failed, 80 passed)*
- `npm run lint` *(fails: Cannot read .eslintignore file: .gitignore)*

------
https://chatgpt.com/codex/tasks/task_b_68a376b27068832b9919f57cd6c40610